### PR TITLE
Fix two bugs.

### DIFF
--- a/config/packages/nyholm_psr7.yaml
+++ b/config/packages/nyholm_psr7.yaml
@@ -1,0 +1,21 @@
+services:
+    # Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)
+    Psr\Http\Message\RequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@nyholm.psr7.psr17_factory'
+
+    # Register nyholm/psr7 services for autowiring with HTTPlug factories
+    Http\Message\MessageFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\RequestFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\ResponseFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\StreamFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\UriFactory: '@nyholm.psr7.httplug_factory'
+
+    nyholm.psr7.psr17_factory:
+        class: Nyholm\Psr7\Factory\Psr17Factory
+
+    nyholm.psr7.httplug_factory:
+        class: Nyholm\Psr7\Factory\HttplugFactory

--- a/migrations/2021/07/Version20210705172757.php
+++ b/migrations/2021/07/Version20210705172757.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210705172757 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE transactions DROP FOREIGN KEY `FK_EAA81A4C12284F3C`, DROP FOREIGN KEY `FK_EAA81A4C95242202`');
+        $this->addSql('ALTER TABLE transactions CHANGE COLUMN `first_party_id` `first_party_id` INT(11) NULL ;');
+        $this->addSql('ALTER TABLE transactions ADD CONSTRAINT `FK_EAA81A4C12284F3C` FOREIGN KEY (`second_party_id`) REFERENCES person (`id`)  ON DELETE SET NULL, ADD CONSTRAINT `FK_EAA81A4C95242202` FOREIGN KEY (`first_party_id`) REFERENCES person (`id`) ON DELETE SET NULL;');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -56,7 +56,7 @@ class Event extends AbstractEntity {
 
     /**
      * @var Collection|Witness[]
-     * @ORM\OneToMany(targetEntity="Witness", mappedBy="event")
+     * @ORM\OneToMany(targetEntity="Witness", mappedBy="event", cascade={"remove"})
      */
     private $witnesses;
 

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -96,43 +96,45 @@ class Person extends AbstractEntity {
 
     /**
      * @var Collection|Residence[]
-     * @ORM\OneToMany(targetEntity="Residence", mappedBy="person")
+     * @ORM\OneToMany(targetEntity="Residence", mappedBy="person", cascade={"remove"})
      */
     private $residences;
 
     /**
      * @var Collection|Relationship[]
-     * @ORM\OneToMany(targetEntity="Relationship", mappedBy="person")
+     * @ORM\OneToMany(targetEntity="Relationship", mappedBy="person", cascade={"remove"})
      */
     private $relationships;
 
     /**
      * @var Collection|Relationship[]
-     * @ORM\OneToMany(targetEntity="Relationship", mappedBy="relation")
+     * @ORM\OneToMany(targetEntity="Relationship", mappedBy="relation", cascade={"remove"})
      */
     private $relations;
 
     /**
      * @var Collection|Witness[]
-     * @ORM\OneToMany(targetEntity="Witness", mappedBy="person")
+     * @ORM\OneToMany(targetEntity="Witness", mappedBy="person", cascade={"remove"})
      */
     private $witnesses;
 
     /**
      * @var Collection|Event[]
-     * @ORM\ManyToMany(targetEntity="Event", mappedBy="participants")
+     * @ORM\ManyToMany(targetEntity="Event", mappedBy="participants", cascade={"remove"})
      */
     private $events;
 
     /**
      * @var Collection|Transaction[]
      * @ORM\OneToMany(targetEntity="Transaction", mappedBy="firstParty")
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private $firstPartyTransactions;
 
     /**
      * @var Collection|Transaction[]
      * @ORM\OneToMany(targetEntity="Transaction", mappedBy="secondParty")
+     * @ORM\JoinColumn(onDelete="SET NULL")
      */
     private $secondPartyTransactions;
 

--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -42,7 +42,7 @@ class Transaction extends AbstractEntity {
      * @ORM\ManyToOne(targetEntity="Person", inversedBy="firstPartyTransactions")
      * @ORM\JoinColumn(nullable=false)
      */
-    private Person $firstParty;
+    private ?Person $firstParty = null;
 
     /**
      * @ORM\Column(type="string")

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -62,6 +62,7 @@ class EventType extends AbstractType {
             'class' => EventCategory::class,
             'remote_route' => 'event_category_typeahead',
             'allow_clear' => true,
+            'required' => true,
             'attr' => [
                 'help_block' => '',
                 'add_path' => 'event_category_new_popup',

--- a/templates/person/partial/detail.html.twig
+++ b/templates/person/partial/detail.html.twig
@@ -149,7 +149,7 @@
                         {% for transaction in person.firstPartyTransactions|sort((a,b) => a.date <=> b.date) %}
                             <li>
                                 <a href='{{ path("transaction_show", {"id":transaction.id }) }}'>
-                                    {{ transaction.date|date('Y-m-d') }}
+                                    {{ transaction.date|date('Y-m-d') -}}
                                 </a>
                                 {{ transaction.category }} {{ transaction.conjunction }}
                                 {% if transaction.secondParty %}
@@ -169,10 +169,13 @@
                         {% for transaction in person.secondPartyTransactions|sort((a,b) => a.date <=> b.date) %}
                             <li>
                                 <a href='{{ path("transaction_show", {"id":transaction.id }) }}'>
-                                    {{ transaction.date|date('Y-m-d') }}
+                                    {{ transaction.date|date('Y-m-d') -}}
                                 </a>
                                 {{ transaction.category }}
-                                <a href='{{ path('person_show', {'id': transaction.firstParty.id}) }}'>{{ transaction.firstParty }}</a> {{ transaction.conjunction }} {{ person }}
+                                {% if transaction.firstParty %}
+                                    <a href='{{ path('person_show', {'id': transaction.firstParty.id}) }}'>{{ transaction.firstParty }}</a>
+                                {% endif %}
+                                {{ transaction.conjunction }} {{ person }}
                             </li>
                         {% endfor %}
                     </ul>

--- a/templates/transaction/partial/table.html.twig
+++ b/templates/transaction/partial/table.html.twig
@@ -17,9 +17,11 @@
                     </a>
                 </td>
                 <td>
+                    {% if transaction.firstParty %}
                     <a href='{{ path('person_show', {'id': transaction.firstParty.id}) }}'>
                         {{ transaction.firstParty }}
                     </a>
+                    {% endif %}
                 </td>
 
                 <td>


### PR DESCRIPTION
1. Cascade removal of some entities.

From person to residences, relationships, relations, witnesses, events and
transactions.

From events to witness

   fixes sfu-dhil/sen#51

2. Make event category required in the event form to match the definition.

   fixes sfu-dhil/sen#52